### PR TITLE
add onAuth function

### DIFF
--- a/src/main/java/org/yeauty/annotation/OnAuth.java
+++ b/src/main/java/org/yeauty/annotation/OnAuth.java
@@ -1,0 +1,11 @@
+package org.yeauty.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OnAuth {
+}

--- a/src/main/java/org/yeauty/pojo/PojoEndpointServer.java
+++ b/src/main/java/org/yeauty/pojo/PojoEndpointServer.java
@@ -234,6 +234,25 @@ public class PojoEndpointServer {
         }
     }
 
+    public boolean doOnAuth(ParameterMap parameterMap) {
+        PojoMethodMapping methodMapping = null;
+        if (pathMethodMappingMap.size() == 1) {
+            methodMapping = pathMethodMappingMap.values().iterator().next();
+            if (methodMapping.getOnAuth() != null) {
+                try {
+                    Object isAuth = methodMapping.getOnAuth().invoke(methodMapping.getEndpointInstance(),
+                            methodMapping.getOnAuthArgs(parameterMap));
+                    return (Boolean)isAuth;
+                } catch (Throwable t) {
+                    logger.error(t);
+                }
+            }else {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public String getHost() {
         return config.getHost();
     }

--- a/src/main/java/org/yeauty/standard/HttpServerHandler.java
+++ b/src/main/java/org/yeauty/standard/HttpServerHandler.java
@@ -191,6 +191,13 @@ class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
             return;
         }
 
+        //auth
+        if(!pojoEndpointServer.doOnAuth(new ParameterMap(originalParam))){
+            res = new DefaultFullHttpResponse(HTTP_1_1, UNAUTHORIZED);
+            sendHttpResponse(ctx, req, res);
+            return;
+        }
+
         // Handshake
         Channel channel = ctx.channel();
         WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req), null, true, config.getmaxFramePayloadLength());

--- a/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
@@ -84,7 +84,6 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
             PojoEndpointServer pojoEndpointServer = new PojoEndpointServer(pojoMethodMapping, serverEndpointConfig);
             websocketServer = new WebsocketServer(pojoEndpointServer, serverEndpointConfig);
             addressWebsocketServerMap.put(inetSocketAddress, websocketServer);
-
         } else {
             String path = annotation.value();
             String prefix = annotation.prefix();


### PR DESCRIPTION
添加OnAuth注解 适用方式同其他注解.如果serverEndPoint类不存在该注解则不执行权限校验操作.如果有,则执行. 其主要实现原理是通过获取到websocket第一次连接时的参数parameterMap 然后针对参数进行校验 返回true or false,满足用户自定义权限校验的需求