### PR TITLE
Allow non overridden method

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ public class MyWebSocket {
 |writerIdleTimeSeconds|0|the same as `writerIdleTimeSeconds` in `IdleStateHandler` and add `IdleStateHandler` to `pipeline` when it is not 0
 |allIdleTimeSeconds|0|the same as `allIdleTimeSeconds` in `IdleStateHandler` and add `IdleStateHandler` to `pipeline` when it is not 0
 |maxFramePayloadLength|65536|Maximum allowable frame payload length.
+|allowNonOverriddenMethods|false|Whether to allow non-overridden methods of ServerEndPoint subclasses to override parent methods
 
 ### Configuration by application.properties
 > You can get the configurate of `application.properties` by using `${...}` placeholders. for example：

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ public class MyWebSocket {
         }
     }
     
-    @OnOpen
+    @OnOpen 
     public void onOpen(Session session, HttpHeaders headers, @RequestParam String req, @RequestParam MultiValueMap reqMap, @PathVariable String arg, @PathVariable Map pathMap){
         System.out.println("new connection");
         System.out.println(req);

--- a/README_zh.md
+++ b/README_zh.md
@@ -153,6 +153,7 @@ public class MyWebSocket {
 |writerIdleTimeSeconds|0|与`IdleStateHandler`中的`writerIdleTimeSeconds`一致，并且当它不为0时，将在`pipeline`中添加`IdleStateHandler`
 |allIdleTimeSeconds|0|与`IdleStateHandler`中的`allIdleTimeSeconds`一致，并且当它不为0时，将在`pipeline`中添加`IdleStateHandler`
 |maxFramePayloadLength|65536|最大允许帧载荷长度
+|allowNonOverriddenMethods|false|是否允许ServerEndPoint子类的非重写方法覆盖父类方法
 
 ### 通过application.properties进行配置
 > 所有参数皆可使用`${...}`占位符获取`application.properties`中的配置。如下：

--- a/src/main/java/org/yeauty/annotation/ServerEndpoint.java
+++ b/src/main/java/org/yeauty/annotation/ServerEndpoint.java
@@ -71,4 +71,8 @@ public @interface ServerEndpoint {
 
     String maxFramePayloadLength() default "65536";
 
+    //------------------------- Application settings -------------------------
+
+    String allowNonOverriddenMethods() default "false";
+
 }

--- a/src/main/java/org/yeauty/pojo/PojoMethodMapping.java
+++ b/src/main/java/org/yeauty/pojo/PojoMethodMapping.java
@@ -64,6 +64,8 @@ public class PojoMethodMapping {
         Method event = null;
         Method[] pojoClazzMethods = null;
         Class<?> currentClazz = pojoClazz;
+        ServerEndpoint serverEndpoint = currentClazz.getAnnotation(ServerEndpoint.class);
+        boolean allowNonOverriddenMethods = "true".equals(serverEndpoint.allowNonOverriddenMethods());
         while (!currentClazz.equals(Object.class)) {
             Method[] currentClazzMethods = currentClazz.getDeclaredMethods();
             if (currentClazz == pojoClazz) {
@@ -76,6 +78,7 @@ public class PojoMethodMapping {
                         handshake = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(handshake, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(
@@ -88,6 +91,7 @@ public class PojoMethodMapping {
                         open = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(open, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(
@@ -100,6 +104,7 @@ public class PojoMethodMapping {
                         close = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(close, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(
@@ -112,6 +117,7 @@ public class PojoMethodMapping {
                         error = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(error, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(
@@ -124,6 +130,7 @@ public class PojoMethodMapping {
                         message = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(message, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(
@@ -136,6 +143,7 @@ public class PojoMethodMapping {
                         binary = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(binary, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(
@@ -148,6 +156,7 @@ public class PojoMethodMapping {
                         event = method;
                     } else {
                         if (currentClazz == pojoClazz ||
+                                !allowNonOverriddenMethods &&
                                 !isMethodOverride(event, method)) {
                             // Duplicate annotation
                             throw new DeploymentException(

--- a/src/main/java/org/yeauty/standard/HttpServerHandler.java
+++ b/src/main/java/org/yeauty/standard/HttpServerHandler.java
@@ -214,7 +214,7 @@ class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
         }
 
         // Handshake
-        WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req), subprotocols, true, config.getmaxFramePayloadLength());
+        WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req), subprotocols, true, config.getMaxFramePayloadLength());
         WebSocketServerHandshaker handshaker = wsFactory.newHandshaker(req);
         if (handshaker == null) {
             WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(channel);

--- a/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
@@ -35,9 +35,10 @@ public class ServerEndpointConfig {
     private final int WRITER_IDLE_TIME_SECONDS;
     private final int ALL_IDLE_TIME_SECONDS;
     private final int MAX_FRAME_PAYLOAD_LENGTH;
+    private final boolean ALLOW_NON_OVERRIDDEN_METHODS;
     private static Integer randomPort;
 
-    public ServerEndpointConfig(String host, int port, String path, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength) {
+    public ServerEndpointConfig(String host, int port, String path, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength,boolean allowNonOverriddenMethods) {
         if (StringUtils.isEmpty(host) || "0.0.0.0".equals(host) || "0.0.0.0/0.0.0.0".equals(host)) {
             this.HOST = "0.0.0.0";
         } else {
@@ -64,6 +65,7 @@ public class ServerEndpointConfig {
         this.WRITER_IDLE_TIME_SECONDS = writerIdleTimeSeconds;
         this.ALL_IDLE_TIME_SECONDS = allIdleTimeSeconds;
         this.MAX_FRAME_PAYLOAD_LENGTH = maxFramePayloadLength;
+        this.ALLOW_NON_OVERRIDDEN_METHODS=allowNonOverriddenMethods;
     }
 
 
@@ -187,7 +189,11 @@ public class ServerEndpointConfig {
         return ALL_IDLE_TIME_SECONDS;
     }
 
-    public int getmaxFramePayloadLength() {
+    public int getMaxFramePayloadLength() {
         return MAX_FRAME_PAYLOAD_LENGTH;
+    }
+
+    public boolean getAllowNonOverriddenMethods(){
+        return ALLOW_NON_OVERRIDDEN_METHODS;
     }
 }

--- a/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
@@ -134,9 +134,12 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
         int writerIdleTimeSeconds = resolveAnnotationValue(annotation.writerIdleTimeSeconds(), Integer.class, "writerIdleTimeSeconds");
         int allIdleTimeSeconds = resolveAnnotationValue(annotation.allIdleTimeSeconds(), Integer.class, "allIdleTimeSeconds");
 
+
         int maxFramePayloadLength = resolveAnnotationValue(annotation.maxFramePayloadLength(), Integer.class, "maxFramePayloadLength");
 
-        ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, path, bossLoopGroupThreads, workerLoopGroupThreads, useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark, childOptionWriteBufferLowWaterMark, childOptionSoRcvbuf, childOptionSoSndbuf, childOptionTcpNodelay, childOptionSoKeepalive, childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds, maxFramePayloadLength);
+        boolean allowNonOverriddenMethods=resolveAnnotationValue(annotation.allowNonOverriddenMethods(),Boolean.class,"annotation.maxFramePayloadLength()");
+
+        ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, path, bossLoopGroupThreads, workerLoopGroupThreads, useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark, childOptionWriteBufferLowWaterMark, childOptionSoRcvbuf, childOptionSoSndbuf, childOptionTcpNodelay, childOptionSoKeepalive, childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds, maxFramePayloadLength,allowNonOverriddenMethods);
         return serverEndpointConfig;
     }
 


### PR DESCRIPTION
以往的逻辑：对于一个被@ServerEndPoint注解的类（以下直接简称Server类）来说，如果该类存在继承关系，如：父子类中都有@BeforeHandShake方法，但两个方法不是重写关系，按照以往的逻辑来说，会就直接报错。

但是实际使用起来发现：如果用户新建一个Server类（称为A），想复用另一个已经存在的Server类（称为B）中的**大部分方法**，而小部分的方法则希望在子类中另外实现（和B中的对应方法不构成父子方法重写关系）。这种情况，用户无法使用继承，因为会报错，只能无奈地在A类中把B类的大部分实现Copy一份，造成代码冗余

新加的功能为：让“是否允许非重写方法覆盖父类的方法”成为一个可插拔的控制，在@ServerEndPoint注解中进行配置，默认为false，也就是和原来一样（不允许这个动作）；设置为true的话可以解决上面描述的问题
