### PR TITLE
0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,13 +239,14 @@ src/
 
 #### 0.9.4
 
-- Bug fixed ：when there is no  `@BeforeHandshake` , `Session` in `OnOpen` is null.
+- Bug fixed ：when there is no  `@BeforeHandshake` , `Session` in `OnOpen` is null
 
 #### 0.9.5
 
-- Bug fixed ：`Throwable` in `OnError` event  is null.
+- Bug fixed ：`Throwable` in `OnError` event  is null
 
 #### 0.10.0
 
 - Modified the default value of `bossLoopGroupThreads` to 1
-- Supports configuring `useEventExecutorGroup` to run synchronous and time-consuming business logic in EventExecutorGroup, so that the I/O thread is not blocked by a time-consuming task.
+- Supports configuring `useEventExecutorGroup` to run synchronous and time-consuming business logic in EventExecutorGroup, so that the I/O thread is not blocked by a time-consuming task
+- SSL supported

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ public class MyWebSocket {
 |writerIdleTimeSeconds|0|the same as `writerIdleTimeSeconds` in `IdleStateHandler` and add `IdleStateHandler` to `pipeline` when it is not 0
 |allIdleTimeSeconds|0|the same as `allIdleTimeSeconds` in `IdleStateHandler` and add `IdleStateHandler` to `pipeline` when it is not 0
 |maxFramePayloadLength|65536|Maximum allowable frame payload length.
+|useEventExecutorGroup|false|Whether to use another thread pool to perform time-consuming synchronous business logic
+|eventExecutorGroupThreads|16|num of threads in bossEventLoopGroup
 
 ### Configuration by application.properties
 > You can get the configurate of `application.properties` by using `${...}` placeholders. for example：
@@ -242,3 +244,8 @@ src/
 #### 0.9.5
 
 - Bug fixed ：`Throwable` in `OnError` event  is null.
+
+#### 0.10.0
+
+- Modified the default value of `bossLoopGroupThreads` to 1
+- Supports configuring `useEventExecutorGroup` to run synchronous and time-consuming business logic in EventExecutorGroup, so that the I/O thread is not blocked by a time-consuming task.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ public class MyWebSocket {
 |maxFramePayloadLength|65536|Maximum allowable frame payload length.
 |useEventExecutorGroup|true|Whether to use another thread pool to perform time-consuming synchronous business logic
 |eventExecutorGroupThreads|16|num of threads in bossEventLoopGroup
+|sslKeyPassword|""(mean not set)|the same as `server.ssl.key-password` in Spring
+|sslKeyStore|""(mean not set)|the same as `server.ssl.key-store` in Spring
+|sslKeyStorePassword|""(mean not set)|the same as `server.ssl.key-store-password` in Spring
+|sslKeyStoreType|""(mean not set)|the same as `server.ssl.key-store-type` in Spring
+|sslTrustStore|""(mean not set)|the same as `server.ssl.trust-store` in Spring
+|sslTrustStorePassword|""(mean not set)|the same as `server.ssl.trust-store-password` in Spring
+|sslTrustStoreType|""(mean not set)|the same as `server.ssl.trust-store-type` in Spring
+|corsOrigins|{}(mean not set)|the same as `@CrossOrigin#origins` in Spring
+|corsAllowCredentials|""(mean not set)|the same as `@CrossOrigin#allowCredentials` in Spring
 
 ### Configuration by application.properties
 > You can get the configurate of `application.properties` by using `${...}` placeholders. for example：
@@ -250,3 +259,4 @@ src/
 - Modified the default value of `bossLoopGroupThreads` to 1
 - Supports configuring `useEventExecutorGroup` to run synchronous and time-consuming business logic in EventExecutorGroup, so that the I/O thread is not blocked by a time-consuming task
 - SSL supported
+- CORS supported

--- a/README.md
+++ b/README.md
@@ -260,3 +260,5 @@ src/
 - Supports configuring `useEventExecutorGroup` to run synchronous and time-consuming business logic in EventExecutorGroup, so that the I/O thread is not blocked by a time-consuming task
 - SSL supported
 - CORS supported
+- Update `Netty` version to `4.1.49.Final`
+

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ public class MyWebSocket {
 |writerIdleTimeSeconds|0|the same as `writerIdleTimeSeconds` in `IdleStateHandler` and add `IdleStateHandler` to `pipeline` when it is not 0
 |allIdleTimeSeconds|0|the same as `allIdleTimeSeconds` in `IdleStateHandler` and add `IdleStateHandler` to `pipeline` when it is not 0
 |maxFramePayloadLength|65536|Maximum allowable frame payload length.
-|useEventExecutorGroup|false|Whether to use another thread pool to perform time-consuming synchronous business logic
+|useEventExecutorGroup|true|Whether to use another thread pool to perform time-consuming synchronous business logic
 |eventExecutorGroupThreads|16|num of threads in bossEventLoopGroup
 
 ### Configuration by application.properties

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ netty-websocket-spring-boot-starter will help you develop WebSocket server by us
 	<dependency>
 		<groupId>org.yeauty</groupId>
 		<artifactId>netty-websocket-spring-boot-starter</artifactId>
-		<version>0.9.5</version>
+		<version>0.10.0</version>
 	</dependency>
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -153,7 +153,7 @@ public class MyWebSocket {
 |writerIdleTimeSeconds|0|与`IdleStateHandler`中的`writerIdleTimeSeconds`一致，并且当它不为0时，将在`pipeline`中添加`IdleStateHandler`
 |allIdleTimeSeconds|0|与`IdleStateHandler`中的`allIdleTimeSeconds`一致，并且当它不为0时，将在`pipeline`中添加`IdleStateHandler`
 |maxFramePayloadLength|65536|最大允许帧载荷长度
-|useEventExecutorGroup|false|是否使用另一个线程池来执行耗时的同步业务逻辑
+|useEventExecutorGroup|true|是否使用另一个线程池来执行耗时的同步业务逻辑
 |eventExecutorGroupThreads|16|eventExecutorGroup的线程数
 
 ### 通过application.properties进行配置

--- a/README_zh.md
+++ b/README_zh.md
@@ -155,6 +155,15 @@ public class MyWebSocket {
 |maxFramePayloadLength|65536|最大允许帧载荷长度
 |useEventExecutorGroup|true|是否使用另一个线程池来执行耗时的同步业务逻辑
 |eventExecutorGroupThreads|16|eventExecutorGroup的线程数
+|sslKeyPassword|""(即未设置)|与Spring的`server.ssl.key-password`一致
+|sslKeyStore|""(即未设置)|与Spring的`server.ssl.key-store`一致
+|sslKeyStorePassword|""(即未设置)|与Spring的`server.ssl.key-store-password`一致
+|sslKeyStoreType|""(即未设置)|与Spring的`server.ssl.key-store-type`一致
+|sslTrustStore|""(即未设置)|与Spring的`server.ssl.trust-store`一致
+|sslTrustStorePassword|""(即未设置)|与Spring的`server.ssl.trust-store-password`一致
+|sslTrustStoreType|""(即未设置)|与Spring的`server.ssl.trust-store-type`一致
+|corsOrigins|{}(即未设置)|与Spring的`@CrossOrigin#origins`一致
+|corsAllowCredentials|""(即未设置)|与Spring的`@CrossOrigin#allowCredentials`一致
 
 ### 通过application.properties进行配置
 > 所有参数皆可使用`${...}`占位符获取`application.properties`中的配置。如下：
@@ -249,3 +258,4 @@ src/
 - 修改`bossLoopGroupThreads`默认值为1
 - 支持通过配置`useEventExecutorGroup`让同步且耗时的业务逻辑在EventExecutorGroup中执行，防止I/O线程被耗时的任务阻塞
 - 支持SSL
+- 支持跨域

--- a/README_zh.md
+++ b/README_zh.md
@@ -259,3 +259,4 @@ src/
 - 支持通过配置`useEventExecutorGroup`让同步且耗时的业务逻辑在EventExecutorGroup中执行，防止I/O线程被耗时的任务阻塞
 - 支持SSL
 - 支持跨域
+- 更新`Netty`版本到 `4.1.59.Final`

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,7 +18,7 @@ netty-websocket-spring-boot-starter [![License](http://img.shields.io/:license-a
 	<dependency>
 		<groupId>org.yeauty</groupId>
 		<artifactId>netty-websocket-spring-boot-starter</artifactId>
-		<version>0.9.5</version>
+		<version>0.10.0</version>
 	</dependency>
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -153,6 +153,8 @@ public class MyWebSocket {
 |writerIdleTimeSeconds|0|与`IdleStateHandler`中的`writerIdleTimeSeconds`一致，并且当它不为0时，将在`pipeline`中添加`IdleStateHandler`
 |allIdleTimeSeconds|0|与`IdleStateHandler`中的`allIdleTimeSeconds`一致，并且当它不为0时，将在`pipeline`中添加`IdleStateHandler`
 |maxFramePayloadLength|65536|最大允许帧载荷长度
+|useEventExecutorGroup|false|是否使用另一个线程池来执行耗时的同步业务逻辑
+|eventExecutorGroupThreads|16|eventExecutorGroup的线程数
 
 ### 通过application.properties进行配置
 > 所有参数皆可使用`${...}`占位符获取`application.properties`中的配置。如下：
@@ -241,3 +243,8 @@ src/
 #### 0.9.5
 
 - 修复bug：`OnError`事件中的`Throwable`为null.
+
+#### 0.10.0
+
+- 修改`bossLoopGroupThreads`默认值为1
+- 支持通过配置`useEventExecutorGroup`让同步且耗时的业务逻辑在EventExecutorGroup中执行，防止I/O线程被耗时的任务阻塞

--- a/README_zh.md
+++ b/README_zh.md
@@ -248,3 +248,4 @@ src/
 
 - 修改`bossLoopGroupThreads`默认值为1
 - 支持通过配置`useEventExecutorGroup`让同步且耗时的业务逻辑在EventExecutorGroup中执行，防止I/O线程被耗时的任务阻塞
+- 支持SSL

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </scm>
 
     <properties>
-        <netty.version>4.1.56.Final</netty.version>
+        <netty.version>4.1.59.Final</netty.version>
         <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.yeauty</groupId>
     <artifactId>netty-websocket-spring-boot-starter</artifactId>
-    <version>0.9.5</version>
+    <version>0.10.0</version>
 
     <name>netty-websocket-spring-boot-starter</name>
     <description>
@@ -36,7 +36,7 @@
     </scm>
 
     <properties>
-        <netty.version>4.1.50.Final</netty.version>
+        <netty.version>4.1.56.Final</netty.version>
         <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
     </properties>
 

--- a/src/main/java/org/yeauty/annotation/ServerEndpoint.java
+++ b/src/main/java/org/yeauty/annotation/ServerEndpoint.java
@@ -77,4 +77,20 @@ public @interface ServerEndpoint {
 
     String eventExecutorGroupThreads() default "16";
 
+    //------------------------- ssl (refer to spring) -------------------------
+
+    String sslKeyPassword() default "";
+
+    String sslKeyStore() default "";            //e.g. classpath:server.jks
+
+    String sslKeyStorePassword() default "";
+
+    String sslKeyStoreType() default "";        //e.g. JKS
+
+    String sslTrustStore() default "";
+
+    String sslTrustStorePassword() default "";
+
+    String sslTrustStoreType() default "";
+
 }

--- a/src/main/java/org/yeauty/annotation/ServerEndpoint.java
+++ b/src/main/java/org/yeauty/annotation/ServerEndpoint.java
@@ -73,7 +73,7 @@ public @interface ServerEndpoint {
 
     //------------------------- eventExecutorGroup -------------------------
 
-    String useEventExecutorGroup() default "false"; //use EventExecutorGroup(another thread pool) to perform time-consuming synchronous business logic
+    String useEventExecutorGroup() default "true"; //use EventExecutorGroup(another thread pool) to perform time-consuming synchronous business logic
 
     String eventExecutorGroupThreads() default "16";
 

--- a/src/main/java/org/yeauty/annotation/ServerEndpoint.java
+++ b/src/main/java/org/yeauty/annotation/ServerEndpoint.java
@@ -77,7 +77,11 @@ public @interface ServerEndpoint {
 
     String eventExecutorGroupThreads() default "16";
 
-    //------------------------- ssl (refer to spring) -------------------------
+    //------------------------- ssl (refer to spring Ssl) -------------------------
+
+    /**
+     * {@link org.springframework.boot.web.server.Ssl}
+     */
 
     String sslKeyPassword() default "";
 
@@ -92,5 +96,16 @@ public @interface ServerEndpoint {
     String sslTrustStorePassword() default "";
 
     String sslTrustStoreType() default "";
+
+    //------------------------- cors (refer to spring CrossOrigin) -------------------------
+
+    /**
+     * {@link org.springframework.web.bind.annotation.CrossOrigin}
+     */
+
+    String[] corsOrigins() default {};
+
+    String corsAllowCredentials() default "";
+
 
 }

--- a/src/main/java/org/yeauty/annotation/ServerEndpoint.java
+++ b/src/main/java/org/yeauty/annotation/ServerEndpoint.java
@@ -71,4 +71,10 @@ public @interface ServerEndpoint {
 
     String maxFramePayloadLength() default "65536";
 
+    //------------------------- eventExecutorGroup -------------------------
+
+    String useEventExecutorGroup() default "false"; //use EventExecutorGroup(another thread pool) to perform time-consuming synchronous business logic
+
+    String eventExecutorGroupThreads() default "16";
+
 }

--- a/src/main/java/org/yeauty/standard/HttpServerHandler.java
+++ b/src/main/java/org/yeauty/standard/HttpServerHandler.java
@@ -13,6 +13,7 @@ import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketSe
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.util.StringUtils;
 import org.yeauty.pojo.PojoEndpointServer;
@@ -30,6 +31,7 @@ class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 
     private final PojoEndpointServer pojoEndpointServer;
     private final ServerEndpointConfig config;
+    private final EventExecutorGroup eventExecutorGroup;
 
     private static ByteBuf faviconByteBuf = null;
     private static ByteBuf notFoundByteBuf = null;
@@ -57,6 +59,7 @@ class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
         }
     }
 
+
     private static ByteBuf buildStaticRes(String resPath) {
         try {
             InputStream inputStream = HttpServerHandler.class.getResourceAsStream(resPath);
@@ -73,9 +76,10 @@ class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
         return null;
     }
 
-    public HttpServerHandler(PojoEndpointServer pojoEndpointServer, ServerEndpointConfig config) {
+    public HttpServerHandler(PojoEndpointServer pojoEndpointServer, ServerEndpointConfig config, EventExecutorGroup eventExecutorGroup) {
         this.pojoEndpointServer = pojoEndpointServer;
         this.config = config;
+        this.eventExecutorGroup = eventExecutorGroup;
     }
 
     @Override
@@ -228,7 +232,11 @@ class HttpServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
                 pipeline.addLast(new WebSocketServerCompressionHandler());
             }
             pipeline.addLast(new WebSocketFrameAggregator(Integer.MAX_VALUE));
-            pipeline.addLast(new WebSocketServerHandler(pojoEndpointServer));
+            if (config.isUseEventExecutorGroup()) {
+                pipeline.addLast(eventExecutorGroup, new WebSocketServerHandler(pojoEndpointServer));
+            } else {
+                pipeline.addLast(new WebSocketServerHandler(pojoEndpointServer));
+            }
             String finalPattern = pattern;
             handshaker.handshake(channel, req).addListener(future -> {
                 if (future.isSuccess()) {

--- a/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
@@ -16,7 +16,7 @@ public class ServerEndpointConfig {
 
     private final String HOST;
     private final int PORT;
-//    private final Set<String> PATH_SET;
+    //    private final Set<String> PATH_SET;
     private final int BOSS_LOOP_GROUP_THREADS;
     private final int WORKER_LOOP_GROUP_THREADS;
     private final boolean USE_COMPRESSION_HANDLER;
@@ -37,17 +37,24 @@ public class ServerEndpointConfig {
     private final int MAX_FRAME_PAYLOAD_LENGTH;
     private final boolean USE_EVENT_EXECUTOR_GROUP;
     private final int EVENT_EXECUTOR_GROUP_THREADS;
+
+    private final String KEY_PASSWORD;
+    private final String KEY_STORE;
+    private final String KEY_STORE_PASSWORD;
+    private final String KEY_STORE_TYPE;
+    private final String TRUST_STORE;
+    private final String TRUST_STORE_PASSWORD;
+    private final String TRUST_STORE_TYPE;
+
     private static Integer randomPort;
 
-    public ServerEndpointConfig(String host, int port, String path, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength, boolean useEventExecutorGroup , int eventExecutorGroupThreads) {
+    public ServerEndpointConfig(String host, int port, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength, boolean useEventExecutorGroup, int eventExecutorGroupThreads, String keyPassword, String keyStore, String keyStorePassword, String keyStoreType, String trustStore, String trustStorePassword, String trustStoreType) {
         if (StringUtils.isEmpty(host) || "0.0.0.0".equals(host) || "0.0.0.0/0.0.0.0".equals(host)) {
             this.HOST = "0.0.0.0";
         } else {
             this.HOST = host;
         }
         this.PORT = getAvailablePort(port);
-//        PATH_SET = new HashSet<>();
-//        addPath(path);
         this.BOSS_LOOP_GROUP_THREADS = bossLoopGroupThreads;
         this.WORKER_LOOP_GROUP_THREADS = workerLoopGroupThreads;
         this.USE_COMPRESSION_HANDLER = useCompressionHandler;
@@ -68,19 +75,15 @@ public class ServerEndpointConfig {
         this.MAX_FRAME_PAYLOAD_LENGTH = maxFramePayloadLength;
         this.USE_EVENT_EXECUTOR_GROUP = useEventExecutorGroup;
         this.EVENT_EXECUTOR_GROUP_THREADS = eventExecutorGroupThreads;
+
+        this.KEY_PASSWORD = keyPassword;
+        this.KEY_STORE = keyStore;
+        this.KEY_STORE_PASSWORD = keyStorePassword;
+        this.KEY_STORE_TYPE = keyStoreType;
+        this.TRUST_STORE = trustStore;
+        this.TRUST_STORE_PASSWORD = trustStorePassword;
+        this.TRUST_STORE_TYPE = trustStoreType;
     }
-
-
-    /*public String addPath(String path) {
-        if (StringUtils.isEmpty(path)) {
-            path = "/";
-        }
-        if (PATH_SET.contains(path)) {
-            throw new RuntimeException("ServerEndpointConfig.addPath  path:" + path + " are repeat.");
-        }
-        this.PATH_SET.add(path);
-        return path;
-    }*/
 
     private int getAvailablePort(int port) {
         if (port != 0) {
@@ -201,5 +204,33 @@ public class ServerEndpointConfig {
 
     public int getEventExecutorGroupThreads() {
         return EVENT_EXECUTOR_GROUP_THREADS;
+    }
+
+    public String getKeyPassword() {
+        return KEY_PASSWORD;
+    }
+
+    public String getKeyStore() {
+        return KEY_STORE;
+    }
+
+    public String getKeyStorePassword() {
+        return KEY_STORE_PASSWORD;
+    }
+
+    public String getKeyStoreType() {
+        return KEY_STORE_TYPE;
+    }
+
+    public String getTrustStore() {
+        return TRUST_STORE;
+    }
+
+    public String getTrustStorePassword() {
+        return TRUST_STORE_PASSWORD;
+    }
+
+    public String getTrustStoreType() {
+        return TRUST_STORE_TYPE;
     }
 }

--- a/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
@@ -5,8 +5,6 @@ import org.springframework.util.StringUtils;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author Yeauty
@@ -16,7 +14,6 @@ public class ServerEndpointConfig {
 
     private final String HOST;
     private final int PORT;
-    //    private final Set<String> PATH_SET;
     private final int BOSS_LOOP_GROUP_THREADS;
     private final int WORKER_LOOP_GROUP_THREADS;
     private final boolean USE_COMPRESSION_HANDLER;
@@ -46,9 +43,12 @@ public class ServerEndpointConfig {
     private final String TRUST_STORE_PASSWORD;
     private final String TRUST_STORE_TYPE;
 
+    private final String[] CORS_ORIGINS;
+    private final Boolean CORS_ALLOW_CREDENTIALS;
+
     private static Integer randomPort;
 
-    public ServerEndpointConfig(String host, int port, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength, boolean useEventExecutorGroup, int eventExecutorGroupThreads, String keyPassword, String keyStore, String keyStorePassword, String keyStoreType, String trustStore, String trustStorePassword, String trustStoreType) {
+    public ServerEndpointConfig(String host, int port, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength, boolean useEventExecutorGroup, int eventExecutorGroupThreads, String keyPassword, String keyStore, String keyStorePassword, String keyStoreType, String trustStore, String trustStorePassword, String trustStoreType, String[] corsOrigins, Boolean corsAllowCredentials) {
         if (StringUtils.isEmpty(host) || "0.0.0.0".equals(host) || "0.0.0.0/0.0.0.0".equals(host)) {
             this.HOST = "0.0.0.0";
         } else {
@@ -83,6 +83,9 @@ public class ServerEndpointConfig {
         this.TRUST_STORE = trustStore;
         this.TRUST_STORE_PASSWORD = trustStorePassword;
         this.TRUST_STORE_TYPE = trustStoreType;
+
+        this.CORS_ORIGINS = corsOrigins;
+        this.CORS_ALLOW_CREDENTIALS = corsAllowCredentials;
     }
 
     private int getAvailablePort(int port) {
@@ -232,5 +235,13 @@ public class ServerEndpointConfig {
 
     public String getTrustStoreType() {
         return TRUST_STORE_TYPE;
+    }
+
+    public String[] getCorsOrigins() {
+        return CORS_ORIGINS;
+    }
+
+    public Boolean getCorsAllowCredentials() {
+        return CORS_ALLOW_CREDENTIALS;
     }
 }

--- a/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointConfig.java
@@ -35,9 +35,11 @@ public class ServerEndpointConfig {
     private final int WRITER_IDLE_TIME_SECONDS;
     private final int ALL_IDLE_TIME_SECONDS;
     private final int MAX_FRAME_PAYLOAD_LENGTH;
+    private final boolean USE_EVENT_EXECUTOR_GROUP;
+    private final int EVENT_EXECUTOR_GROUP_THREADS;
     private static Integer randomPort;
 
-    public ServerEndpointConfig(String host, int port, String path, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength) {
+    public ServerEndpointConfig(String host, int port, String path, int bossLoopGroupThreads, int workerLoopGroupThreads, boolean useCompressionHandler, int connectTimeoutMillis, int soBacklog, int writeSpinCount, int writeBufferHighWaterMark, int writeBufferLowWaterMark, int soRcvbuf, int soSndbuf, boolean tcpNodelay, boolean soKeepalive, int soLinger, boolean allowHalfClosure, int readerIdleTimeSeconds, int writerIdleTimeSeconds, int allIdleTimeSeconds, int maxFramePayloadLength, boolean useEventExecutorGroup , int eventExecutorGroupThreads) {
         if (StringUtils.isEmpty(host) || "0.0.0.0".equals(host) || "0.0.0.0/0.0.0.0".equals(host)) {
             this.HOST = "0.0.0.0";
         } else {
@@ -64,6 +66,8 @@ public class ServerEndpointConfig {
         this.WRITER_IDLE_TIME_SECONDS = writerIdleTimeSeconds;
         this.ALL_IDLE_TIME_SECONDS = allIdleTimeSeconds;
         this.MAX_FRAME_PAYLOAD_LENGTH = maxFramePayloadLength;
+        this.USE_EVENT_EXECUTOR_GROUP = useEventExecutorGroup;
+        this.EVENT_EXECUTOR_GROUP_THREADS = eventExecutorGroupThreads;
     }
 
 
@@ -189,5 +193,13 @@ public class ServerEndpointConfig {
 
     public int getmaxFramePayloadLength() {
         return MAX_FRAME_PAYLOAD_LENGTH;
+    }
+
+    public boolean isUseEventExecutorGroup() {
+        return USE_EVENT_EXECUTOR_GROUP;
+    }
+
+    public int getEventExecutorGroupThreads() {
+        return EVENT_EXECUTOR_GROUP_THREADS;
     }
 }

--- a/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
@@ -18,6 +18,7 @@ import org.yeauty.exception.DeploymentException;
 import org.yeauty.pojo.PojoEndpointServer;
 import org.yeauty.pojo.PojoMethodMapping;
 
+import javax.net.ssl.SSLException;
 import java.net.InetSocketAddress;
 import java.util.*;
 
@@ -77,6 +78,9 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
                 logger.info(String.format("\033[34mNetty WebSocket started on port: %s with context path(s): %s .\033[0m", pojoEndpointServer.getPort(), stringJoiner.toString()));
             } catch (InterruptedException e) {
                 logger.error(String.format("websocket [%s] init fail", entry.getKey()), e);
+            } catch (SSLException e) {
+                logger.error(String.format("websocket [%s] ssl create fail", entry.getKey()), e);
+
             }
         }
     }
@@ -139,7 +143,23 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
         boolean useEventExecutorGroup = resolveAnnotationValue(annotation.useEventExecutorGroup(), Boolean.class, "useEventExecutorGroup");
         int eventExecutorGroupThreads = resolveAnnotationValue(annotation.eventExecutorGroupThreads(), Integer.class, "eventExecutorGroupThreads");
 
-        ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, path, bossLoopGroupThreads, workerLoopGroupThreads, useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark, childOptionWriteBufferLowWaterMark, childOptionSoRcvbuf, childOptionSoSndbuf, childOptionTcpNodelay, childOptionSoKeepalive, childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds, maxFramePayloadLength, useEventExecutorGroup, eventExecutorGroupThreads);
+        String sslKeyPassword = resolveAnnotationValue(annotation.sslKeyPassword(), String.class, "sslKeyPassword");
+        String sslKeyStore = resolveAnnotationValue(annotation.sslKeyStore(), String.class, "sslKeyStore");
+        String sslKeyStorePassword = resolveAnnotationValue(annotation.sslKeyStorePassword(), String.class, "sslKeyStorePassword");
+        String sslKeyStoreType = resolveAnnotationValue(annotation.sslKeyStoreType(), String.class, "sslKeyStoreType");
+        String sslTrustStore = resolveAnnotationValue(annotation.sslTrustStore(), String.class, "sslTrustStore");
+        String sslTrustStorePassword = resolveAnnotationValue(annotation.sslTrustStorePassword(), String.class, "sslTrustStorePassword");
+        String sslTrustStoreType = resolveAnnotationValue(annotation.sslTrustStoreType(), String.class, "sslTrustStoreType");
+
+
+        ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, bossLoopGroupThreads, workerLoopGroupThreads
+                , useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark
+                , childOptionWriteBufferLowWaterMark, childOptionSoRcvbuf, childOptionSoSndbuf, childOptionTcpNodelay, childOptionSoKeepalive
+                , childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds
+                , maxFramePayloadLength, useEventExecutorGroup, eventExecutorGroupThreads
+                , sslKeyPassword, sslKeyStore, sslKeyStorePassword, sslKeyStoreType
+                , sslTrustStore, sslTrustStorePassword, sslTrustStoreType);
+
         return serverEndpointConfig;
     }
 

--- a/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
@@ -151,6 +151,13 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
         String sslTrustStorePassword = resolveAnnotationValue(annotation.sslTrustStorePassword(), String.class, "sslTrustStorePassword");
         String sslTrustStoreType = resolveAnnotationValue(annotation.sslTrustStoreType(), String.class, "sslTrustStoreType");
 
+        String[] corsOrigins = annotation.corsOrigins();
+        if (corsOrigins.length != 0) {
+            for (int i = 0; i < corsOrigins.length; i++) {
+                corsOrigins[i] = resolveAnnotationValue(corsOrigins[i], String.class, "corsOrigins");
+            }
+        }
+        Boolean corsAllowCredentials = resolveAnnotationValue(annotation.corsAllowCredentials(), Boolean.class, "corsAllowCredentials");
 
         ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, bossLoopGroupThreads, workerLoopGroupThreads
                 , useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark
@@ -158,7 +165,8 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
                 , childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds
                 , maxFramePayloadLength, useEventExecutorGroup, eventExecutorGroupThreads
                 , sslKeyPassword, sslKeyStore, sslKeyStorePassword, sslKeyStoreType
-                , sslTrustStore, sslTrustStorePassword, sslTrustStoreType);
+                , sslTrustStore, sslTrustStorePassword, sslTrustStoreType
+                , corsOrigins, corsAllowCredentials);
 
         return serverEndpointConfig;
     }

--- a/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
@@ -136,7 +136,10 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
 
         int maxFramePayloadLength = resolveAnnotationValue(annotation.maxFramePayloadLength(), Integer.class, "maxFramePayloadLength");
 
-        ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, path, bossLoopGroupThreads, workerLoopGroupThreads, useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark, childOptionWriteBufferLowWaterMark, childOptionSoRcvbuf, childOptionSoSndbuf, childOptionTcpNodelay, childOptionSoKeepalive, childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds, maxFramePayloadLength);
+        boolean useEventExecutorGroup = resolveAnnotationValue(annotation.useEventExecutorGroup(), Boolean.class, "useEventExecutorGroup");
+        int eventExecutorGroupThreads = resolveAnnotationValue(annotation.eventExecutorGroupThreads(), Integer.class, "eventExecutorGroupThreads");
+
+        ServerEndpointConfig serverEndpointConfig = new ServerEndpointConfig(host, port, path, bossLoopGroupThreads, workerLoopGroupThreads, useCompressionHandler, optionConnectTimeoutMillis, optionSoBacklog, childOptionWriteSpinCount, childOptionWriteBufferHighWaterMark, childOptionWriteBufferLowWaterMark, childOptionSoRcvbuf, childOptionSoSndbuf, childOptionTcpNodelay, childOptionSoKeepalive, childOptionSoLinger, childOptionAllowHalfClosure, readerIdleTimeSeconds, writerIdleTimeSeconds, allIdleTimeSeconds, maxFramePayloadLength, useEventExecutorGroup, eventExecutorGroupThreads);
         return serverEndpointConfig;
     }
 

--- a/src/main/java/org/yeauty/util/SslUtils.java
+++ b/src/main/java/org/yeauty/util/SslUtils.java
@@ -1,0 +1,65 @@
+package org.yeauty.util;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.springframework.util.ResourceUtils;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+import java.net.URL;
+import java.security.KeyStore;
+
+/**
+ * refer to {@link org.springframework.boot.web.embedded.netty.SslServerCustomizer}
+ */
+public final class SslUtils {
+
+    public static SslContext createSslContext(String keyPassword, String keyStoreResource, String keyStoreType, String keyStorePassword, String trustStoreResource, String trustStoreType, String trustStorePassword) throws SSLException {
+        SslContextBuilder sslBuilder = SslContextBuilder
+                .forServer(getKeyManagerFactory(keyStoreType, keyStoreResource, keyPassword, keyStorePassword))
+                .trustManager(getTrustManagerFactory(trustStoreType, trustStoreResource, trustStorePassword));
+        return sslBuilder.build();
+    }
+
+    private static KeyManagerFactory getKeyManagerFactory(String type, String resource, String keyPassword, String keyStorePassword) {
+        try {
+            KeyStore keyStore = loadKeyStore(type, resource, keyStorePassword);
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory
+                    .getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            char[] keyPasswordBytes = (keyPassword != null
+                    ? keyPassword.toCharArray() : null);
+            if (keyPasswordBytes == null && keyStorePassword != null) {
+                keyPasswordBytes = keyStorePassword.toCharArray();
+            }
+            keyManagerFactory.init(keyStore, keyPasswordBytes);
+            return keyManagerFactory;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static TrustManagerFactory getTrustManagerFactory(String trustStoreType, String trustStoreResource, String trustStorePassword) {
+        try {
+            KeyStore store = loadKeyStore(trustStoreType, trustStoreResource, trustStorePassword);
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory
+                    .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(store);
+            return trustManagerFactory;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static KeyStore loadKeyStore(String type, String resource, String password)
+            throws Exception {
+        type = (type == null ? "JKS" : type);
+        if (resource == null) {
+            return null;
+        }
+        KeyStore store = KeyStore.getInstance(type);
+        URL url = ResourceUtils.getURL(resource);
+        store.load(url.openStream(), password == null ? null : password.toCharArray());
+        return store;
+    }
+}

--- a/src/main/java/org/yeauty/util/SslUtils.java
+++ b/src/main/java/org/yeauty/util/SslUtils.java
@@ -3,6 +3,7 @@ package org.yeauty.util;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import org.springframework.util.ResourceUtils;
+import org.springframework.util.StringUtils;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
@@ -27,9 +28,9 @@ public final class SslUtils {
             KeyStore keyStore = loadKeyStore(type, resource, keyStorePassword);
             KeyManagerFactory keyManagerFactory = KeyManagerFactory
                     .getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            char[] keyPasswordBytes = (keyPassword != null
+            char[] keyPasswordBytes = (!StringUtils.isEmpty(keyPassword)
                     ? keyPassword.toCharArray() : null);
-            if (keyPasswordBytes == null && keyStorePassword != null) {
+            if (keyPasswordBytes == null && !StringUtils.isEmpty(keyStorePassword)) {
                 keyPasswordBytes = keyStorePassword.toCharArray();
             }
             keyManagerFactory.init(keyStore, keyPasswordBytes);
@@ -53,13 +54,13 @@ public final class SslUtils {
 
     private static KeyStore loadKeyStore(String type, String resource, String password)
             throws Exception {
-        type = (type == null ? "JKS" : type);
-        if (resource == null) {
+        type = (StringUtils.isEmpty(type) ? "JKS" : type);
+        if (StringUtils.isEmpty(resource)) {
             return null;
         }
         KeyStore store = KeyStore.getInstance(type);
         URL url = ResourceUtils.getURL(resource);
-        store.load(url.openStream(), password == null ? null : password.toCharArray());
+        store.load(url.openStream(), StringUtils.isEmpty(password) ? null : password.toCharArray());
         return store;
     }
 }


### PR DESCRIPTION
- Modified the default value of `bossLoopGroupThreads` to 1
- Supports configuring `useEventExecutorGroup` to run synchronous and time-consuming business logic in EventExecutorGroup, so that the I/O thread is not blocked by a time-consuming task
- SSL supported
- CORS supported
- Update `Netty` version to `4.1.49.Final`