### PR TITLE
Compatible with CGLIB in AOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,6 @@ src/
 - CORS supported
 - Update `Netty` version to `4.1.49.Final`
 
+#### 0.11.0
+
+- When the `ServerEndpoint` class is proxied by CGLIB (as with AOP enhancement), it still works

--- a/README_zh.md
+++ b/README_zh.md
@@ -260,3 +260,7 @@ src/
 - 支持SSL
 - 支持跨域
 - 更新`Netty`版本到 `4.1.59.Final`
+
+#### 0.11.0
+
+- 当`ServerEndpoint`类被cglib代理时(如aop增强)，仍能正常运行

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.yeauty</groupId>
     <artifactId>netty-websocket-spring-boot-starter</artifactId>
-    <version>0.10.0</version>
+    <version>0.11.0</version>
 
     <name>netty-websocket-spring-boot-starter</name>
     <description>

--- a/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
+++ b/src/main/java/org/yeauty/standard/ServerEndpointExporter.java
@@ -13,6 +13,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ApplicationObjectSupport;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.env.Environment;
+import org.springframework.util.ClassUtils;
 import org.yeauty.annotation.ServerEndpoint;
 import org.yeauty.exception.DeploymentException;
 import org.yeauty.pojo.PojoEndpointServer;
@@ -61,7 +62,11 @@ public class ServerEndpointExporter extends ApplicationObjectSupport implements 
         }
 
         for (Class<?> endpointClass : endpointClasses) {
-            registerEndpoint(endpointClass);
+            if (ClassUtils.isCglibProxyClass(endpointClass)){
+                registerEndpoint(endpointClass.getSuperclass());
+            }else {
+                registerEndpoint(endpointClass);
+            }
         }
 
         init();


### PR DESCRIPTION
When the 'ServerEndpoint' class is proxied by CGLIB (as with AOP enhancement), it still works