### PR TITLE
Bug fixed: WebSocketServerCompressionHandler invalid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.yeauty</groupId>
     <artifactId>netty-websocket-spring-boot-starter</artifactId>
-    <version>0.12.0</version>
+    <version>0.12.1</version>
 
     <name>netty-websocket-spring-boot-starter</name>
     <description>


### PR DESCRIPTION
问题所在：

WebSocketServerCompressionHandler在握手请求已被当前handler消费后才添加
握手响应在WebSocketServerCompressionHandler添加后才发送
导致WebSocketServerCompressionHandler永远无法处理原始握手请求中的扩展信息

修复原理：

ctx.fireChannelRead(req.retain()) 将HTTP请求转发给pipeline中的下一个处理器
这使得WebSocketServerCompressionHandler能够接收并处理原始HTTP请求
在处理过程中，WebSocketServerCompressionHandler会解析Sec-WebSocket-Extensions头
内部状态变化：

WebSocketServerCompressionHandler在内部维护了扩展协商状态
当它处理HTTP请求时，会解析客户端请求的扩展并存储有效扩展
这个信息存储在handler的validExtensions字段中
响应头更新机制：

当握手响应通过pipeline时，WebSocketServerCompressionHandler的write方法被调用
此时它会检查之前存储的validExtensions并修改响应头
添加Sec-WebSocket-Extensions: permessage-deflate到响应中